### PR TITLE
Reliable PhraseCard speech button disabling

### DIFF
--- a/components/PhraseCard.js
+++ b/components/PhraseCard.js
@@ -40,8 +40,21 @@ export default function PhraseCard({
       }
 
       // Continue checking isSpeakingAsync until it returns false
-      while (await isSpeakingAsync()) {
+      let stopCount = 0;
+
+      while (true) {
         await new Promise((resolve) => setTimeout(resolve, 100));
+
+        if (!(await isSpeakingAsync())) {
+          stopCount++;
+
+          // Check if isSpeakingAsync() has returned false more than two times
+          if (stopCount > 2) {
+            break; // Exit the loop
+          }
+        } else {
+          stopCount = 0; // Reset the counter if isSpeakingAsync() returns true
+        }
       }
     } catch (error) {
       console.error("Error speaking phrase:", error);


### PR DESCRIPTION
When a PhraseCard's words are being spoken, it now checks twice to confirm that it has stopped speaking before allowing its speech button to be pressed again.