### PR TITLE
Make "X" button clear translation output

### DIFF
--- a/screens/Translation.js
+++ b/screens/Translation.js
@@ -238,6 +238,7 @@ const Translation = ({ navigation }) => {
                         icon="close"
                         onPress={() => {
                           setTranslationInput("");
+                          setTranslationOutput("");
                         }}
                       />
                     ) : null}


### PR DESCRIPTION
Formerly only cleared input