### PR TITLE
Fix "undefined dimension" warning during registration

### DIFF
--- a/styles/globalStyles.js
+++ b/styles/globalStyles.js
@@ -178,7 +178,7 @@ export const settingsStyle = StyleSheet.create({
   squareImage: {
     display: "flex",
     width: "60%",
-    height: "undefined",
+    height: undefined,
     aspectRatio: "1",
     marginTop: "2%",
     marginBottom: "8%",


### PR DESCRIPTION
- squareImage style from globalStyles previously defined a dimension as string "undefined" rather than raw value `undefined`, causing an error.
- It now uses the correct `undefined` value.