### PR TITLE
Update parsing of PhraseData to use updated attributes

### DIFF
--- a/components/PhraseCard.js
+++ b/components/PhraseCard.js
@@ -34,9 +34,9 @@ export default function PhraseCard({
       setIsSpeaking(true);
 
       if (inUserLang) {
-        speak(phrase.text_translated, { language: "en" });
+        speak(phrase.translatedtext, { language: "en" });
       } else {
-        speak(phrase.text_original, { language: "es" });
+        speak(phrase.originaltext, { language: "es" });
       }
 
       // Continue checking isSpeakingAsync until it returns false
@@ -84,12 +84,12 @@ export default function PhraseCard({
               <Card.Content style={styles.cardContent}>
                 {inUserLang ? (
                   <SelectableWordList
-                    data={phrase.text_translated}
+                    data={phrase.translatedtext}
                     onSelectWord={onSelectEnglishWord}
                   />
                 ) : (
                   <SelectableWordList
-                    data={phrase.text_original}
+                    data={phrase.originaltext}
                     onSelectWord={onSelectSpanishWord}
                   />
                 )}
@@ -122,10 +122,7 @@ export default function PhraseCard({
                         icon="shuffle-variant"
                         mode="default"
                         onPress={() => {
-                          updateGeneratedPhrase(
-                            phrase.userid,
-                            phrase.generated_phrases_id,
-                          );
+                          updateGeneratedPhrase(phrase.userid, phrase.id);
                         }}
                       />
                     </>

--- a/screens/Phrases.js
+++ b/screens/Phrases.js
@@ -136,8 +136,7 @@ const Phrases = ({ navigation }) => {
       // to the one being requested for saving, then push it to currentPhrases.
       if (
         !currentPhrases.some(
-          (currentPhrase) =>
-            currentPhrase.text_original === phrase.text_original,
+          (currentPhrase) => currentPhrase.originaltext === phrase.originaltext,
         )
       ) {
         currentPhrases.push(phrase);
@@ -198,15 +197,13 @@ const Phrases = ({ navigation }) => {
 
   const updateGeneratedPhrase = async (userID, phraseID) => {
     const updatedPhrases = [...generatedPhrases];
-    const index = updatedPhrases.findIndex(
-      (phrase) => phrase.generated_phrases_id === phraseID,
-    );
+    const index = updatedPhrases.findIndex((phrase) => phrase.id === phraseID);
     updatedPhrases[index].isloading = true;
     setGeneratedPhrases(updatedPhrases);
 
     const data = {
-      user_id: userID,
-      phrase_id: phraseID,
+      userid: userID,
+      id: phraseID,
     };
 
     const options = {

--- a/screens/SavedPhrases.js
+++ b/screens/SavedPhrases.js
@@ -70,6 +70,7 @@ const SavedPhrases = ({ navigation }) => {
       updatedPhrases = currentPhrases.filter(
         (currentPhrase) => currentPhrase.originaltext !== phrase.originaltext,
       );
+      setPhraseData(updatedPhrases);
     } catch (e) {
       console.log("Error", e);
     }
@@ -80,7 +81,7 @@ const SavedPhrases = ({ navigation }) => {
         JSON.stringify(updatedPhrases),
       );
       // Signal that a storage change occurred by a simple bit flip
-      setStorageChange((prevStorageChange) => !prevStorageChange);
+      // setStorageChange((prevStorageChange) => !prevStorageChange);
     } catch (e) {
       console.log("Error", e);
     }

--- a/screens/SavedPhrases.js
+++ b/screens/SavedPhrases.js
@@ -68,7 +68,7 @@ const SavedPhrases = ({ navigation }) => {
       // the given function, which checks that the text of the passed
       // currentPhrase does not match the text of the phrase to be deleted.
       updatedPhrases = currentPhrases.filter(
-        (currentPhrase) => currentPhrase.text_original !== phrase.text_original,
+        (currentPhrase) => currentPhrase.originaltext !== phrase.originaltext,
       );
     } catch (e) {
       console.log("Error", e);


### PR DESCRIPTION
Note: previously stored phrases should be deleted before pulling this change, as they will create errors from being in an outdated format.